### PR TITLE
Modified the showLists command to not print the file extension

### DIFF
--- a/src/main/java/ch/heigvd/dai/commands/ShowLists.java
+++ b/src/main/java/ch/heigvd/dai/commands/ShowLists.java
@@ -25,7 +25,9 @@ public class ShowLists implements Callable<Integer> {
         try (java.nio.file.DirectoryStream<java.nio.file.Path> stream = java.nio.file.Files.newDirectoryStream(dir, "*.tdm")) {
             boolean hasFiles = false;
             for (java.nio.file.Path entry : stream) {
-                System.out.println(entry.getFileName().toString());
+                String nameToDisplay = entry.getFileName().toString();
+                String result = nameToDisplay.split(".tdm")[0];
+                System.out.println(result);
                 hasFiles = true;
             }
             if (!hasFiles) {


### PR DESCRIPTION
Used the split() method on the name to only keep the first part